### PR TITLE
fixes to run README code

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -36,7 +36,7 @@ plot_epi <- function(simepi) {
     ggplot2::scale_y_log10() + 
     ggplot2::scale_color_manual(values = col.pop) +
     ggplot2::theme_bw()+
-    ggplot2::theme(panel.grid.minor.y = element_blank() ) + 
+    ggplot2::theme(panel.grid.minor.y = ggplot2::element_blank() ) + 
     ggplot2::labs(title = 'Population')
   # g.pop 
   


### PR DESCRIPTION
the code in the `README` didn't work (without additionally calling `library(ggplot2)`) as there was a call to `element_blank()` in `plot_sim()` that wasn't prefaced with `ggplot2::`. this PR fixes that.

still having trouble trying to run the fitting README code... trying to troubleshoot but i'm not quite sure how to use the `trace()` method of reference classes to get into a method and find the bug.