### PR TITLE
patch B date fill warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: reem
 Type: Package
 Title: Renewal Equation based Epidemic Model 
-Version: 0.8.4
+Version: 0.8.5
 Date: 2024-08-28
 Author: David Champredon
 Maintainer: David Champredon <david.champredon@canada.ca>

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -290,14 +290,15 @@ check_B <- function(obj) {
     obj$prms[['B']] <- rbind(B.fillin, obj$prms[['B']])
   }
   
-  if(obj$prms[['B']]$date[nrow(obj$prms[['B']])] < date.horiz){
+  # refresh values in case modified by previous `if()`
+  nb = nrow(obj$prms[['B']])
+  
+  if(obj$prms[['B']]$date[nb] < date.horiz){
     warning(
       'Last date (',obj$prms[['B']]$date[nb],') for behavior change parameter `B` ', 
       'is before horizon date (',date.horiz,').\n',
       'Filling-in missing values with last element B[n].')
 
-    # refresh values in case modified by previous `if()`
-    nb = nrow(obj$prms[['B']])
     
     # Filling-in missing dates:
     d2 = seq.Date(obj$prms[['B']]$date[nb]+1, date.horiz, by = 1)

--- a/tests/testthat/test-fit_abc.R
+++ b/tests/testthat/test-fit_abc.R
@@ -1,111 +1,121 @@
-
 test_that("fit_abc works", {
-  
-  date.start = lubridate::ymd('2022-01-01')
-  asof       = date.start + 90
-  
-  prms0 = list(
-    horizon = 300,  # horizon of the simulation
-    last.obs = 299,  # last observation time (must be < horizon)
-    B       = rep(1,300), # Behavior change
+  date.start <- lubridate::ymd("2022-01-01")
+  asof <- date.start + 90
+  horizon <- 300
+
+  prms0 <- list(
+    horizon = horizon, # horizon of the simulation
+    last.obs = horizon - 1, # last observation time (must be < horizon)
+    B = data.frame( # Behavior change, buffer start and end dates
+      # to compensate for start.delta going between -7 and 7 in fit
+      date = seq(date.start - 14, date.start + horizon - 1 + 14, by = 1),
+      mult = rep(1, horizon + 28)
+    ),
     freq.obs.ww = 3, # average frequency of ww observation
-    t.obs.cl = seq(7,280, by = 7),
-    t.obs.ww = seq(3,200, by=3),
-    i0prop  = 1e-3,
+    t.obs.cl = seq(7, 280, by = 7),
+    t.obs.ww = seq(3, 200, by = 3),
+    i0prop = 1e-3,
     date.start = date.start,
-    start.delta = 0, 
-    R0      = 1.8, # Basic reproduction number
-    N       = 1e4, # population size
-    alpha   = 0.5, # transmission heterogeneity (alpha=0: homogeneous)
-    I.init  = c(1,1,3,5), # initial incidence (overwritten in fit ABC)
-    lag     = 7,   # Aggregation lag for clinical reports
-    rho     = 0.1, # mean reporting ratio
-    g       = get_gi(), # Generation interval distribution
-    fec     = get_fecalshed(), # fecal shedding kinetics
-    kappa   = 0.18, # decay in ww
-    psi     = get_psi(),   # plug flow simulation,
+    start.delta = 0,
+    R0 = 1.8, # Basic reproduction number
+    N = 1e4, # population size
+    alpha = 0.5, # transmission heterogeneity (alpha=0: homogeneous)
+    I.init = c(1, 1, 3, 5), # initial incidence (overwritten in fit ABC)
+    lag = 7, # Aggregation lag for clinical reports
+    rho = 0.1, # mean reporting ratio
+    g = get_gi(), # Generation interval distribution
+    fec = get_fecalshed(), # fecal shedding kinetics
+    kappa = 0.18, # decay in ww
+    psi = get_psi(), # plug flow simulation,
     shed.mult = 1e-3
   )
-  
-  obj0 = new('reem', 
-             name = 'foo0', 
-             prms = prms0, 
-             is.fitted = FALSE)
-  
+
+  obj0 <- new("reem",
+    name = "foo0",
+    prms = prms0,
+    is.fitted = FALSE
+  )
+
   # Simulate data
   set.seed(1234)
-  simepi  = obj0$simulate_epi(deterministic = FALSE)
-  obs.cl = dplyr::filter(simepi$obs.cl, date <= asof)
-  obs.ww = dplyr::filter(simepi$obs.ww, date <= asof)
-  obs.ha = dplyr::filter(simepi$obs.ha, date <= asof)
-  
-  # mess with the dates such that they 
+  simepi <- obj0$simulate_epi(deterministic = FALSE)
+  obs.cl <- dplyr::filter(simepi$obs.cl, date <= asof)
+  obs.ww <- dplyr::filter(simepi$obs.ww, date <= asof)
+  obs.ha <- dplyr::filter(simepi$obs.ha, date <= asof)
+
+  # mess with the dates such that they
   # do not perfectly align with the simulation
-  obs.cl$t    <- obs.cl$t + 1
+  obs.cl$t <- obs.cl$t + 1
   obs.cl$date <- obs.cl$date + 1
-  obs.ha$t    <- obs.ha$t + 1
+  obs.ha$t <- obs.ha$t + 1
   obs.ha$date <- obs.ha$date + 1
-  obs.ww$t    <- obs.ww$t + 1
+  obs.ww$t <- obs.ww$t + 1
   obs.ww$date <- obs.ww$date + 1
-  
+
   # Attached simulated data to new `reem` object:
-  prms = prms0
+  prms <- prms0
   prms$t.obs.cl <- obs.cl$t
   prms$t.obs.ww <- obs.ww$t
-  obj  = new('reem', 
-             name = 'foo', 
-             prms = prms, 
-             obs.cl = obs.cl,
-             obs.ha = obs.ha,
-             obs.ww = obs.ww,
-             is.fitted = FALSE)
-  
+  obj <- new("reem",
+    name = "foo",
+    prms = prms,
+    obs.cl = obs.cl,
+    obs.ha = obs.ha,
+    obs.ww = obs.ww,
+    is.fitted = FALSE
+  )
+
   # ---- Fit ----
-  
-  prm.abc = list(
+
+  prm.abc <- list(
     n.abc = 1000,
-    n.sim = 0,     #`0` for deterministic, else`8` should be enough
-    p.abc = 0.02, #1e-2,
-    n.cores = 1, #min(12, parallel::detectCores() - 1),
-    use.cl = 1, 
+    n.sim = 0, # `0` for deterministic, else`8` should be enough
+    p.abc = 0.02, # 1e-2,
+    n.cores = 1, # min(12, parallel::detectCores() - 1),
+    use.cl = 1,
     use.ha = 1,
     use.ww = 1,
-    err.type = 'L2'
+    err.type = "L2"
   )
-  
-  prms.to.fit = list(
-    R0          = list('gamma', 2, 0.251),
-    alpha       = list('norm', 1, 1),
-    i0prop      = list('unif', -5, -2),
-    start.delta = list('unif_int', -7, 7)  
+
+  prms.to.fit <- list(
+    R0          = list("gamma", 2, 0.251),
+    alpha       = list("norm", 1, 1),
+    i0prop      = list("unif", -5, -2),
+    start.delta = list("unif_int", -7, 7)
   )
-  
-  thefit = obj$fit_abc(prm.abc, prms.to.fit)  
-  
+
+  thefit <- obj$fit_abc(prm.abc, prms.to.fit)
+
   # -- Check posterior values to known parameter values
-  
-  R0.post    = thefit$post.prms$R0  
-  alpha.post = thefit$post.prms$alpha  
-  i0.post    = thefit$post.prms$i0prop
-  
-  if(0){ # DEBUG 
-    gg = obj$plot_fit()
+
+  R0.post <- thefit$post.prms$R0
+  alpha.post <- thefit$post.prms$alpha
+  i0.post <- thefit$post.prms$i0prop
+
+  if (0) { # DEBUG
+    gg <- obj$plot_fit()
     gg$all
   }
-  ci.check = 0.9
-  qt.check = c(0.5 - ci.check/2, 0.5 + ci.check/2)
-  
-  ci.R0    = stats::quantile(R0.post, probs = qt.check)
-  ci.alpha = stats::quantile(alpha.post, probs = qt.check)
-  ci.i0    = stats::quantile(i0.post, probs = qt.check)
-  
-  testthat::expect_true(ci.R0[1] <= prms0$R0 & prms0$R0 <= ci.R0[2], 
-                        "R0 does not seem to be well fitted.")
-  
-  testthat::expect_true(ci.alpha[1] <= prms0$alpha & prms0$alpha <= ci.alpha[2], 
-                        "`alpha` does not seem to be well fitted.")
-  
-  testthat::expect_true(ci.i0[1] <= log10(prms0$i0) & log10(prms0$R0 <= ci.i0[2]), 
-                        "i0prop does not seem to be well fitted.")
-  
+  ci.check <- 0.9
+  qt.check <- c(0.5 - ci.check / 2, 0.5 + ci.check / 2)
+
+  ci.R0 <- stats::quantile(R0.post, probs = qt.check)
+  ci.alpha <- stats::quantile(alpha.post, probs = qt.check)
+  ci.i0 <- stats::quantile(i0.post, probs = qt.check)
+
+  testthat::expect_true(
+    ci.R0[1] <= prms0$R0 & prms0$R0 <= ci.R0[2],
+    "R0 does not seem to be well fitted."
+  )
+
+  testthat::expect_true(
+    ci.alpha[1] <= prms0$alpha & prms0$alpha <= ci.alpha[2],
+    "`alpha` does not seem to be well fitted."
+  )
+
+  testthat::expect_true(
+    ci.i0[1] <= log10(prms0$i0) & log10(prms0$R0 <= ci.i0[2]),
+    "i0prop does not seem to be well fitted."
+  )
 })

--- a/tests/testthat/test-simulate_epi.R
+++ b/tests/testthat/test-simulate_epi.R
@@ -1,73 +1,81 @@
 test_that("simulate_epi works", {
-  
-  date.start = lubridate::ymd('2022-01-01')
-  asof       = lubridate::ymd('2022-03-01') 
-  
+  date.start <- lubridate::ymd("2022-01-01")
+  asof <- lubridate::ymd("2022-03-01")
+  B.rows <- 300
+
   ## DO NOT CHANGE PARAMETERS!
   ## (if changed, then adjust tests on numerical values accordingly)
-  
-  prms = list(
-    horizon = 120,  # horizon of the simulation
-    last.obs = 299,  # last observation time (must be < horizon)
-    B       = rep(1,300), # Behavior change
+
+  prms <- list(
+    horizon = 120, # horizon of the simulation
+    last.obs = 299, # last observation time (must be < horizon)
+    B = data.frame( # Behavior change
+      date   = seq(date.start, date.start + B.rows - 1, by = 1),
+      mult   = rep(1, B.rows)
+    ),
     freq.obs.ww = 3, # average frequency of ww observation
-    t.obs.cl = seq(7,280, by = 7),
-    t.obs.ww = seq(3,200, by=3),
+    t.obs.cl = seq(7, 280, by = 7),
+    t.obs.ww = seq(3, 200, by = 3),
     date.start = date.start,
-    start.delta = 0, 
-    R0      = 1.5, # Basic reproduction number
-    N       = 1e4, # population size
-    alpha   = 0.2, # transmission heterogeneity (alpha=0: homogeneous)
-    I.init  = c(1,1,3,5), # initial incidence (overwritten in fit ABC)
-    lag     = 7,   # Aggregation lag for clinical reports
-    rho     = 0.1, # mean reporting ratio
-    g       = get_gi(), # Generation interval distribution
-    fec     = get_fecalshed(), # fecal shedding kinetics
-    kappa   = 0.18, # decay in ww
-    psi     = get_psi(), # plug flow simulation,
-    shed.mult = 0.2 # deposited fecal shedding multiplier  
+    start.delta = 0,
+    R0 = 1.5, # Basic reproduction number
+    N = 1e4, # population size
+    alpha = 0.2, # transmission heterogeneity (alpha=0: homogeneous)
+    I.init = c(1, 1, 3, 5), # initial incidence (overwritten in fit ABC)
+    lag = 7, # Aggregation lag for clinical reports
+    rho = 0.1, # mean reporting ratio
+    g = get_gi(), # Generation interval distribution
+    fec = get_fecalshed(), # fecal shedding kinetics
+    kappa = 0.18, # decay in ww
+    psi = get_psi(), # plug flow simulation,
+    shed.mult = 0.2 # deposited fecal shedding multiplier
   )
-  
-  obj = new('reem', 
-            name = 'forthetest', 
-            prms = prms, 
-            is.fitted = FALSE)
-  
-  expect_true(class(obj) == 'reem')
-  expect_true(class(obj$obs.cl) == 'data.frame')
-  expect_true(class(obj$obs.ww) == 'data.frame')
-  expect_equal(nrow(obj$obs.cl), 0)   # no observations were defined
-  expect_equal(nrow(obj$obs.ww), 0)   # no observations were defined
+
+  obj <- new("reem",
+    name = "forthetest",
+    prms = prms,
+    is.fitted = FALSE
+  )
+
+  expect_true(class(obj) == "reem")
+  expect_true(class(obj$obs.cl) == "data.frame")
+  expect_true(class(obj$obs.ww) == "data.frame")
+  expect_equal(nrow(obj$obs.cl), 0) # no observations were defined
+  expect_equal(nrow(obj$obs.ww), 0) # no observations were defined
   expect_true(!obj$is.fitted)
-  
-  simepi  = obj$simulate_epi(deterministic = FALSE)
-  expect_type(simepi, 'list')
+
+  simepi <- obj$simulate_epi(deterministic = FALSE)
+  expect_type(simepi, "list")
   expect_equal(length(simepi), 4)
-  check.names.simepi = all(names(simepi) %in% c('sim', 
-                                                'obs.cl',
-                                                'obs.ha',
-                                                'obs.ww'))
+  check.names.simepi <- all(names(simepi) %in% c(
+    "sim",
+    "obs.cl",
+    "obs.ha",
+    "obs.ww"
+  ))
   expect_true(check.names.simepi)
-  
-  
-  sim = simepi$sim
-  expect_true(class(sim) == 'data.frame')
-  check.names.sim = all(names(sim) %in% c("t","m","I","S","A","Y","H",
-                                          "Wd","Wp","Wr","date"))
+
+
+  sim <- simepi$sim
+  expect_true(class(sim) == "data.frame")
+  check.names.sim <- all(names(sim) %in% c(
+    "t", "m", "I", "S", "A", "Y", "H",
+    "Wd", "Wp", "Wr", "date"
+  ))
   expect_true(check.names.sim)
   expect_equal(nrow(sim), prms$horizon)
-  
+
   # ---  Now check that the numerical output values make sense
 
   # Deterministic and set seed for replication
   set.seed(1234)
-  simepi2  = obj$simulate_epi(deterministic = TRUE)
-  sim2 = simepi2$sim  
+  simepi2 <- obj$simulate_epi(deterministic = TRUE)
+  sim2 <- simepi2$sim
   # plot(sim2$S)
-  Imax = round(max(sim2$I))   
-  Ymax = round(max(sim2$Y))   
-  Smin = round(min(sim2$S)) 
+  Imax <- round(max(sim2$I))
+  Ymax <- round(max(sim2$Y))
+  Smin <- round(min(sim2$S))
   expect_equal(Imax, 139)
   expect_equal(Ymax, 109)
-  expect_equal(Smin, 4912)  
+  expect_equal(Smin, 4912)
 })


### PR DESCRIPTION
fixes #20

the first fix to #20 addressed the bug in a conditional due to an out of date index, but it still reported an incorrect last `B` date using the old index. this PR fixes that.

it also updates unit tests to use the new `B` specification so that all tests are now passing and no warnings are generated.